### PR TITLE
Ghost rebrand

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -2,16 +2,16 @@
   "name": "bitcore-message",
   "main": "./bitcore-message.min.js",
   "version": "1.0.3",
-  "homepage": "https://github.com/particl/particl-bitcore-message",
+  "homepage": "https://github.com/ghost-coin/ghost-bitcore-message",
   "authors": [
     "BitPay"
   ],
-  "description": "Particl Message Verification and Signing for Particl",
+  "description": "Ghost Message Verification and Signing for Ghost",
   "moduleType": [
     "globals"
   ],
   "keywords": [
-    "particl",
+    "ghost",
     "bitcore",
     "btc",
     "satoshi",

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,7 +1,7 @@
 # Message Verification and Signing
 Bitcore implementation of [bitcoin message signing and verification](http://bitcoin.stackexchange.com/questions/3337/what-are-the-safety-guidelines-for-using-the-sign-message-feature/3339#3339). This is used to cryptographically prove that a certain message was signed by the holder of an address private key.
 
-For more information refer to the [particl-bitcore-message](https://github.com/particl/particl-bitcore-message) github repo.
+For more information refer to the [ghost-bitcore-message](https://github.com/ghost-coin/ghost-bitcore-message) github repo.
 
 ## Installation
 Message Verification and Signing is implemented as a separate module and you must add it to your dependencies:

--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-var bitcore = require('particl-bitcore-lib');
+var bitcore = require('ghost-bitcore-lib');
 bitcore.Message = require('./lib/message');
 
 module.exports = bitcore.Message;

--- a/lib/message.js
+++ b/lib/message.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var bitcore = require('particl-bitcore-lib');
+var bitcore = require('ghost-bitcore-lib');
 var _ = bitcore.deps._;
 var PrivateKey = bitcore.PrivateKey;
 var PublicKey = bitcore.PublicKey;

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "particl-bitcore-message",
+  "name": "ghost-bitcore-message",
   "version": "1.0.3",
-  "description": "Particl Messages for Bitcore",
+  "description": "Ghost Messages for Bitcore",
   "author": "BitPay <dev@bitpay.com>",
   "main": "index.js",
   "scripts": {
@@ -11,7 +11,7 @@
     "build": "gulp"
   },
   "keywords": [
-    "particl",
+    "ghost",
     "bitcore",
     "btc",
     "satoshi",
@@ -20,10 +20,10 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/particl/particl-bitcore-message.git"
+    "url": "https://github.com/ghost-coin/ghost-bitcore-message.git"
   },
   "dependencies": {
-    "particl-bitcore-lib": "git://github.com/particl/particl-bitcore-lib"
+    "ghost-bitcore-lib": "git+ssh://github.com/ghost-coin/ghost-bitcore-lib"
   },
   "devDependencies": {
     "bitcore-build": "bitpay/bitcore-build",

--- a/test/message.js
+++ b/test/message.js
@@ -4,7 +4,7 @@ var chai = require('chai');
 var expect = chai.expect;
 var should = chai.should();
 
-var bitcore = require('particl-bitcore-lib');
+var bitcore = require('ghost-bitcore-lib');
 var Address = bitcore.Address;
 var Signature = bitcore.crypto.Signature;
 var Message = require('../');


### PR DESCRIPTION
We start the pull request from master branch

Changes done:

- Change particl mentions to ghost. On Github on particl organization link changed to ghost-coin
- Add ssh option for install ghost-bitcore-lib
